### PR TITLE
Porting for BTT Octopus

### DIFF
--- a/bltouch.cfg
+++ b/bltouch.cfg
@@ -3,8 +3,8 @@
 # sections into your printer.cfg and change it there.
 
 [bltouch]
-sensor_pin: ^PA2
-control_pin: PA1
+sensor_pin: ^PB7
+control_pin: PB6
 speed: 7
 pin_move_time: 0.675
 sample_retract_dist: 10

--- a/copperhead.cfg
+++ b/copperhead.cfg
@@ -6,7 +6,7 @@
 max_extrude_cross_section: 0.64
 max_extrude_only_distance: 200
 nozzle_diameter: 0.4
-heater_pin: PB1
+heater_pin: PA2
 sensor_type: ATC Semitec 104GT-2
 sensor_pin: PF4
 min_extrude_temp: 170

--- a/dragon-high-flow.cfg
+++ b/dragon-high-flow.cfg
@@ -7,7 +7,7 @@
 max_extrude_cross_section: 0.64
 max_extrude_only_distance: 200
 nozzle_diameter: 0.4
-heater_pin: PB1
+heater_pin: PA2
 sensor_type: ATC Semitec 104GT-2
 sensor_pin: PF4
 min_extrude_temp: 170

--- a/dragon-standard-flow.cfg
+++ b/dragon-standard-flow.cfg
@@ -7,7 +7,7 @@
 max_extrude_cross_section: 0.64
 max_extrude_only_distance: 200
 nozzle_diameter: 0.4
-heater_pin: PB1
+heater_pin: PA2
 sensor_type: ATC Semitec 104GT-2
 sensor_pin: PF4
 min_extrude_temp: 170

--- a/physical-endstops.cfg
+++ b/physical-endstops.cfg
@@ -3,12 +3,12 @@
 # sections into your printer.cfg and change it there.
 
 [stepper_x]
-endstop_pin: PB10
+endstop_pin: PG6
 homing_retract_dist: 5.0
 position_endstop: 0 # Adjust this to your setup
 
 [stepper_y]
-endstop_pin: PE12
+endstop_pin: PG9
 homing_positive_dir: true
 homing_retract_dist: 5.0
 

--- a/probe.cfg
+++ b/probe.cfg
@@ -3,7 +3,7 @@
 # sections into your printer.cfg and change it there.
 
 [probe]
-pin: ^PA2
+pin: ^PB7
 x_offset: -29
 y_offset: -13.5
 z_offset: 0.0

--- a/sensorless-homing.cfg
+++ b/sensorless-homing.cfg
@@ -15,11 +15,11 @@ position_min: -12
 position_endstop: -5
 
 [tmc2209 stepper_x]
-diag_pin: PB10
+diag_pin: PG6
 driver_SGTHRS: 70 # Stall guard threshold, this is your X sensitivity, to adjust, copy this section and override it in printer.cfg.
 
 [tmc2209 stepper_y]
-diag_pin: PE12
+diag_pin: PG9
 driver_SGTHRS: 70 # Stall guard threshold, this is your Y sensitivity, to adjust, copy this section and override it in printer.cfg.
 
 [homing_override]

--- a/speed-limits-performance.cfg
+++ b/speed-limits-performance.cfg
@@ -6,13 +6,13 @@
 # Check https://www.klipper3d.org/Resonance_Compensation.html for input shaper calibration.
 
 [tmc2209 stepper_x]
-uart_pin: PC13
+uart_pin: PC4
 run_current: 1.6
 hold_current: 1.2
 stealthchop_threshold: 1
 
 [tmc2209 stepper_y]
-uart_pin: PE3
+uart_pin: PD11
 run_current: 1.6
 hold_current: 1.2
 stealthchop_threshold: 1

--- a/steppers.cfg
+++ b/steppers.cfg
@@ -6,18 +6,18 @@
 # In the wiring diagram, the Z-steppers are called Z1, Z2, Z3, here they're mapped to z, z1, z2 respectively.
 
 [stepper_x]
-step_pin: PE9
-dir_pin: !PF1
-enable_pin: !PF2
+step_pin: PF13
+dir_pin: !PF12
+enable_pin: !PF14
 rotation_distance: 40
 microsteps: 16
 homing_speed: 50
 homing_retract_dist: 0
 
 [stepper_y]
-step_pin: PE11
-dir_pin: PE8
-enable_pin: !PD7
+step_pin: PG0
+dir_pin: PG1
+enable_pin: !PF15
 rotation_distance: 40
 microsteps: 16
 homing_speed: 50
@@ -25,66 +25,66 @@ homing_retract_dist: 0
 
 [stepper_z]
 endstop_pin: probe:z_virtual_endstop
-step_pin: PE14
-dir_pin: PA0
-enable_pin: !PC3
+step_pin: PG4
+dir_pin: PC1
+enable_pin: !PA0
 rotation_distance: 4
 microsteps: 16
 position_min: -5 # Needed for z-offset calibration and tilt_adjust.
 homing_speed: 10
 
 [stepper_z1]
-step_pin: PD15
-dir_pin: PE7
-enable_pin: !PA3
+step_pin: PF9
+dir_pin: PF10
+enable_pin: !PG2
 rotation_distance: 4
 microsteps: 16
 
 [stepper_z2]
-step_pin: PD13
-dir_pin: PG9
-enable_pin: !PF0
+step_pin: PC13
+dir_pin: PF0
+enable_pin: !PF1
 rotation_distance: 4
 microsteps: 16
 
 [extruder]
-step_pin: PE13
-dir_pin: !PC2
-enable_pin: !PC0
+step_pin: PF11
+dir_pin: !PG3
+enable_pin: !PG5
 microsteps: 16
 
 [tmc2209 stepper_x]
-uart_pin: PC13
+uart_pin: PC4
 run_current: 1.1
 hold_current: 0.500
 stealthchop_threshold: 900
 
 [tmc2209 stepper_y]
-uart_pin: PE3
+uart_pin: PD11
 run_current: 1.1
 hold_current: 0.500
 stealthchop_threshold: 900
 
 [tmc2209 extruder]
-uart_pin: PE1
+uart_pin: PC6
 run_current: 0.5
 hold_current: 0.400
 stealthchop_threshold: 900
 
 [tmc2209 stepper_z]
-uart_pin: PD4
+uart_pin: PC7
 run_current: 1.0
 hold_current: 0.500
 stealthchop_threshold: 900
 
 [tmc2209 stepper_z1]
-uart_pin: PD1
+uart_pin: PF2
 run_current: 1.1
 hold_current: 0.500
 stealthchop_threshold: 900
 
 [tmc2209 stepper_z2]
-uart_pin: PD6
+uart_pin: PE4
 run_current: 1.0
 hold_current: 0.500
 stealthchop_threshold: 900

--- a/v-core-3.cfg
+++ b/v-core-3.cfg
@@ -17,7 +17,7 @@ aliases:
     # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "spi2"
 
 [heater_bed]
-heater_pin: PD12
+heater_pin: PA1
 sensor_pin: PF3
 sensor_type: NTC 100K beta 3950
 min_temp: 0
@@ -25,14 +25,14 @@ max_temp: 120
 pwm_cycle_time: 0.02 # 50hz for european AC, to avoid flickering lights.
 
 [fan]
-pin: PC8
+pin: PA8
 
 [heater_fan toolhead_cooling_fan]
 pin: PE5
 fan_speed: 1
 
 [controller_fan controller_fan]
-pin:  PE6
+pin:  PD12
 
 # These are only safeguards for first time users
 # Modify printer.cfg to tune acceleration.

--- a/v6.cfg
+++ b/v6.cfg
@@ -7,7 +7,7 @@
 max_extrude_cross_section: 0.64
 max_extrude_only_distance: 200
 nozzle_diameter: 0.4
-heater_pin: PB1
+heater_pin: PA2
 sensor_type: ATC Semitec 104GT-2
 sensor_pin: PF4
 min_extrude_temp: 170


### PR DESCRIPTION
This is a fork from v-core-3-klipper-config ported to the BTT Octopus controller board.
All the pins should be correct unless something went bad (must be tested).
All the connections sould respect the same order as per BTT SKR Pro V1.2
Example: motores should be in the same order - X, Y, E, Z1, Z2, Z3