### PR TITLE
Typo - restrart was pointing to wrong path

### DIFF
--- a/scripts/klipper-mcu-added.sh
+++ b/scripts/klipper-mcu-added.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 logfile="/var/log/vcore.log"
 
-echo "RESTART" > /tmp/klipper
+echo "RESTART" > /tmp/printer
 touch "$logfile"
 chmod 664 "$logfile"
 echo "$(date +"%Y-%m-%d %T"): MCU Detected" >> "$logfile"


### PR DESCRIPTION
The current path /tmp/klipper is wrong - it does not point to /dev/pts/0 - it just creates a file with the text RESTART

I realized the udev rule did not see if i reinserted the device, but now it restarts the firmware when the board is seated